### PR TITLE
set library installation directory to ${PREFIX}/lib for compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,10 @@ option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
 # Boiler Plate for installation
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
+# on some architectures libs will be installed into `lib64` by default
+# for compatibility reasons we prefer `lib`
+set(CMAKE_INSTALL_LIBDIR lib) 
+
 
 if(NOT DEFINED CMAKE_C_STANDARD)
   set(CMAKE_C_STANDARD 11)


### PR DESCRIPTION
On certain architectures `GNUInstallDirs` will default to `${PREFIX}/lib64` for the library. However, tmLQCD, for example, looks in `${lemon_install_dir}/lib` for `liblemon.a` and will thus not find it. 